### PR TITLE
refactor: Split main.go into modular files for better maintainability

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -9,7 +9,17 @@
   "imageSize": 100,
   "commit": true,
   "commitConvention": "gitmoji",
-  "contributors": [],
+  "contributors": [
+    {
+      "login": "qiaopengjun5162",
+      "name": "Paxon Qiao 乔鹏军",
+      "avatar_url": "https://avatars.githubusercontent.com/u/124650229?v=4",
+      "profile": "https://github.com/qiaopengjun5162",
+      "contributions": [
+        "content"
+      ]
+    }
+  ],
   "contributorsPerLine": 7,
   "linkToUsage": true
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gogen
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/qiaopengjun5162/gogen)
@@ -141,8 +141,26 @@ pull requests, or improve the project.
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/qiaopengjun5162"><img src="https://avatars.githubusercontent.com/u/124650229?v=4?s=100" width="100px;" alt="Paxon Qiao 乔鹏军"/><br /><sub><b>Paxon Qiao 乔鹏军</b></sub></a><br /><a href="#content-qiaopengjun5162" title="Content">🖋</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td align="center" size="13px" colspan="7">
+        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
+          <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
+        </img>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ### License

--- a/gogen_split/config.go
+++ b/gogen_split/config.go
@@ -1,0 +1,26 @@
+package main
+
+import "regexp"
+
+// ANSI 颜色代码
+const (
+	ColorReset = "\033[0m"
+	ColorRed   = "\033[31m"
+	ColorGreen = "\033[32m"
+	ColorCyan  = "\033[36m"
+)
+
+// Config holds the user-provided variables.
+type Config struct {
+	ProjectName string
+	TemplateSrc string
+	IsLocal     bool
+	Branch      string
+}
+
+// 正则表达式常量
+var (
+	ValidGitURL      = regexp.MustCompile(`^(https://|git@).+$`)
+	ValidProjectName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	RepoNameExtract  = regexp.MustCompile(`([^/?]+)(?:\.git)?(?:\?.*)?$`)
+)

--- a/gogen_split/generator.go
+++ b/gogen_split/generator.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func generateProject(config Config) error {
+	if _, err := os.Stat(config.ProjectName); !os.IsNotExist(err) {
+		return fmt.Errorf("directory '%s' already exists", config.ProjectName)
+	}
+
+	var processor TemplateProcessor
+	if config.IsLocal {
+		processor = &LocalTemplateProcessor{}
+	} else {
+		processor = &GitTemplateProcessor{Branch: config.Branch}
+	}
+
+	if err := processor.Process(config.TemplateSrc, config.ProjectName, config); err != nil {
+		if rmErr := os.RemoveAll(config.ProjectName); rmErr != nil {
+			return fmt.Errorf("failed to process template: %v, cleanup failed: %v", err, rmErr)
+		}
+		return err
+	}
+
+	if err := replaceTemplateVariables(config.ProjectName, config); err != nil {
+		if rmErr := os.RemoveAll(config.ProjectName); rmErr != nil {
+			return fmt.Errorf("failed to replace variables: %v, cleanup failed: %v", err, rmErr)
+		}
+		return err
+	}
+	return nil
+}

--- a/gogen_split/input.go
+++ b/gogen_split/input.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func parseFlags(git, local, branch string) (Config, error) {
+	if git != "" && local != "" {
+		return Config{}, fmt.Errorf("cannot specify both --git and --local")
+	}
+	if git == "" && local == "" {
+		return Config{}, fmt.Errorf("please provide a template source using --git or --local")
+	}
+	return Config{
+		TemplateSrc: git,
+		IsLocal:     local != "",
+		Branch:      branch,
+	}, nil
+}
+
+func extractRepoName(gitURL string) string {
+	matches := RepoNameExtract.FindStringSubmatch(gitURL)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return "new_project"
+}
+
+func getUserInput(config Config) Config {
+	scanner := bufio.NewScanner(os.Stdin)
+	defaultName := config.ProjectName
+	if defaultName == "" {
+		if !config.IsLocal {
+			defaultName = extractRepoName(config.TemplateSrc)
+		} else {
+			base := filepath.Base(config.TemplateSrc)
+			defaultName = strings.ReplaceAll(base, "[^a-zA-Z0-9_-]", "_")
+		}
+	}
+
+	logInput(fmt.Sprintf("Enter project name (default: %s): ", defaultName))
+	scanner.Scan()
+	if name := strings.TrimSpace(scanner.Text()); name != "" {
+		config.ProjectName = name
+	} else {
+		config.ProjectName = defaultName
+	}
+
+	logInput(fmt.Sprintf("Generate project '%s' from %s? (Y/n): ", config.ProjectName, config.TemplateSrc))
+	scanner.Scan()
+	if strings.ToLower(strings.TrimSpace(scanner.Text())) == "n" {
+		logInfo("Operation canceled.")
+		os.Exit(0)
+	}
+	return config
+}
+
+func validateInput(config Config) error {
+	if config.IsLocal {
+		if _, err := os.Stat(config.TemplateSrc); os.IsNotExist(err) {
+			return fmt.Errorf("local template path '%s' does not exist", config.TemplateSrc)
+		}
+	} else {
+		if !ValidGitURL.MatchString(config.TemplateSrc) {
+			return fmt.Errorf("invalid Git URL format: %s", config.TemplateSrc)
+		}
+	}
+	if !ValidProjectName.MatchString(config.ProjectName) {
+		return fmt.Errorf("invalid project name '%s': only letters, numbers, '_', and '-' are allowed", config.ProjectName)
+	}
+	return nil
+}

--- a/gogen_split/main.go
+++ b/gogen_split/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var GitCommit string
+
+func main() {
+	if GitCommit != "" {
+		fmt.Printf("Built from Git commit: %s\n", GitCommit)
+	}
+
+	// 解析命令行参数
+	git := flag.String("git", "", "Git repository URL for the template")
+	local := flag.String("local", "", "Local path to the template")
+	branch := flag.String("branch", "", "Git branch to clone (optional)")
+	flag.Parse()
+
+	config, err := parseFlags(*git, *local, *branch)
+	if err != nil {
+		handleError(err, "Please provide a template source using --git or --local flag.")
+	}
+
+	// 获取用户输入并验证
+	config = getUserInput(config)
+	if err := validateInput(config); err != nil {
+		handleError(err, "")
+	}
+
+	// 生成项目
+	logInfo(fmt.Sprintf("Generating project '%s'...", config.ProjectName))
+	if err := generateProject(config); err != nil {
+		handleError(err, "Failed to generate project")
+	}
+	logSuccess(fmt.Sprintf("Project '%s' generated successfully!", config.ProjectName))
+}

--- a/gogen_split/processor.go
+++ b/gogen_split/processor.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type TemplateProcessor interface {
+	Process(src, dest string, config Config) error
+}
+
+type GitTemplateProcessor struct {
+	Branch string
+}
+
+func (p *GitTemplateProcessor) Process(src, dest string, config Config) error {
+	if src != config.TemplateSrc {
+		return fmt.Errorf("source path mismatch")
+	}
+	logProgress(fmt.Sprintf("Cloning Git repository from '%s'...", src))
+	args := []string{"clone", src, dest}
+	if p.Branch != "" {
+		args = append(args, "--branch", p.Branch)
+		logProgress(fmt.Sprintf("Using branch '%s'...", p.Branch))
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+type LocalTemplateProcessor struct{}
+
+func (p *LocalTemplateProcessor) Process(src, dest string, config Config) error {
+	if src != config.TemplateSrc {
+		return fmt.Errorf("source path mismatch")
+	}
+	logProgress(fmt.Sprintf("Copying local template from '%s'...", src))
+	totalFiles, err := countFiles(src)
+	if err != nil {
+		return err
+	}
+	return copyDir(src, dest, totalFiles)
+}

--- a/gogen_split/utils.go
+++ b/gogen_split/utils.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func handleError(err error, msg string) {
+	if err != nil {
+		if msg != "" {
+			fmt.Printf("%s[ERROR] %s: %v%s\n", ColorRed, msg, err, ColorReset)
+		} else {
+			fmt.Printf("%s[ERROR] %v%s\n", ColorRed, err, ColorReset)
+		}
+		os.Exit(1)
+	}
+}
+
+func logInfo(msg string) {
+	fmt.Printf("%s[INFO] %s%s\n", ColorCyan, msg, ColorReset)
+}
+
+func logSuccess(msg string) {
+	fmt.Printf("%s[SUCCESS] %s%s\n", ColorGreen, msg, ColorReset)
+}
+
+func logInput(msg string) {
+	fmt.Printf("%s[INPUT] %s%s", ColorCyan, msg, ColorReset)
+}
+
+func logProgress(msg string) {
+	fmt.Printf("%s[PROGRESS] %s%s\n", ColorCyan, msg, ColorReset)
+}
+
+func countFiles(dir string) (int, error) {
+	var count int
+	err := filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			count++
+		}
+		return nil
+	})
+	return count, err
+}
+
+func copyDir(src, dest string, totalFiles int) error {
+	if err := os.MkdirAll(dest, 0750); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	var copiedFiles int
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		destPath := filepath.Join(dest, entry.Name())
+		if entry.IsDir() {
+			if err := copyDir(srcPath, destPath, totalFiles); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFile(srcPath, destPath); err != nil {
+				return err
+			}
+			copiedFiles++
+			logProgress(fmt.Sprintf("Copied %d/%d files", copiedFiles, totalFiles))
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dest string) error {
+	in, err := os.Open(filepath.Clean(src))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := in.Close(); err != nil {
+			fmt.Printf("%s[ERROR] Failed to close input file: %v%s\n", ColorRed, err, ColorReset)
+		}
+	}()
+	out, err := os.Create(filepath.Clean(dest))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := out.Close(); err != nil {
+			fmt.Printf("%s[ERROR] Failed to close output file: %v%s\n", ColorRed, err, ColorReset)
+		}
+	}()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func replaceTemplateVariables(dir string, config Config) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			content, err := os.ReadFile(filepath.Clean(path))
+			if err != nil {
+				return err
+			}
+			newContent := strings.ReplaceAll(string(content), "{{project_name}}", config.ProjectName)
+			if newContent != string(content) {
+				return os.WriteFile(path, []byte(newContent), info.Mode())
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
refactor: Split main.go into modular files for better maintainability

- Extracted configuration and constants into config.go
- Moved user input and validation logic to input.go
- Separated template processing into processor.go
- Centralized utility functions (logging, file operations) in utils.go
- Isolated project generation logic into generator.go
- Maintained identical functionality with improved code organization
- No functional changes; purely structural refactoring