### PR TITLE
Record main branch protection

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -2,6 +2,32 @@
 
 ## 2026-06-09
 
+### Main Branch Protection
+
+Changed:
+
+- Enabled GitHub branch protection for `main`.
+- Required status check:
+  - `build-go (ubuntu-latest)`
+- Enabled strict status checks so branches must be up to date before merge.
+- Required pull requests before merging.
+- Enabled stale review dismissal.
+- Enforced protection for admins.
+- Required linear history.
+- Required conversation resolution.
+- Disabled force pushes.
+- Disabled branch deletion.
+- Updated `PRODUCTION.md` with the durable branch protection expectations.
+
+Validation:
+
+- `gh api repos/qiaopengjun5162/gogen/branches/main/protection`
+
+Problems and resolutions:
+
+- Problem: GitHub showed `Your main branch isn't protected`, meaning production code could be force-pushed, deleted, or changed without required CI.
+  Resolution: Configured branch protection through GitHub API and recorded the expected settings in project documentation.
+
 ### Post-Merge Duplicate Implementation Cleanup
 
 Changed:

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -55,6 +55,7 @@ Update these files when relevant:
 - Do not keep duplicate implementations of the same CLI behavior.
 - Keep `justfile` as the canonical local task runner; `Makefile` is a compatibility wrapper.
 - Keep Go task commands isolated from stale shell toolchain settings such as an old `GOROOT`.
+- Keep `main` protected: require pull requests, require `build-go (ubuntu-latest)`, forbid force pushes, forbid deletions, require linear history, and require resolved conversations.
 - Commit only coherent, reviewable changes.
 - Push completed commits when the user asks to continue shared work on the remote branch.
 - If `--no-verify` is necessary, record the hook failure and manual checks in `DEVLOG.md`.


### PR DESCRIPTION
## Summary
- document the enabled main branch protection settings
- record the GitHub API configuration in DEVLOG

## Validation
- just check
