### PR TITLE
Clarify release publishing workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: ${{ github.workspace }}/CHANGELOG.md
+          make_latest: true
+          fail_on_unmatched_files: true
           files: |
             artifacts/gogen-linux/gogen-linux
             artifacts/gogen-windows/gogen-windows.exe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 - Local template copying intentionally skips `.git` directories.
 - Template variable replacement intentionally skips `.git` directories and binary files.
 - PR CI jobs must not reference tag-only container actions; GitHub can prepare container actions before evaluating step-level conditions.
+- Pushing a `v*` tag triggers `.github/workflows/build.yml` release jobs. Existing GitHub Release assets are overwritten by `softprops/action-gh-release@v2`; release notes come from `CHANGELOG.md`.
 - Keep tests focused on CLI behavior and filesystem effects before adding new features.
 
 ## Change Recording

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -2,6 +2,29 @@
 
 ## 2026-06-09
 
+### Release Workflow Clarification
+
+Changed:
+
+- Confirmed that `.github/workflows/build.yml` automatically builds Linux, macOS, and Windows assets on `v*` tag pushes.
+- Confirmed that `softprops/action-gh-release@v2` finds an existing release and overwrites assets with matching names.
+- Made release publishing explicitly set `make_latest: true`.
+- Added `fail_on_unmatched_files: true` so missing release assets fail the workflow.
+- Updated `AGENTS.md` with the durable release workflow behavior.
+
+Validation:
+
+- `gh run view 27189248948 --json status,conclusion,event,headBranch,headSha,jobs`
+- `gh run view 27189248948 --log`
+- `gh release view v0.1.1-gogen-release`
+
+Problems and resolutions:
+
+- Problem: It was unclear whether refreshing `v0.1.1-gogen-release` required manual asset upload or whether CI/CD already handled it.
+  Resolution: Verified that the tag push workflow completed `build-assets` and `release`, deleted the previous assets, uploaded fresh assets, and left the release marked Latest. The workflow now declares Latest behavior explicitly.
+- Problem: Manual release notes can be overwritten by the tag workflow because the release job uses `CHANGELOG.md` as `body_path`.
+  Resolution: Recorded the behavior here and in `AGENTS.md`; edit `CHANGELOG.md` or change the workflow if custom release notes should persist.
+
 ### v0.1.1 Release Refresh
 
 Changed:


### PR DESCRIPTION
## Summary
- Document that pushing a `v*` tag triggers the release workflow and overwrites existing release assets
- Make release publishing explicitly mark releases as Latest
- Fail the release job if expected asset globs are missing

## Validation
- just check
- git diff --check
- gh run view 27189248948 --json status,conclusion,event,headBranch,headSha,jobs
- gh run view 27189248948 --log
- gh release view v0.1.1-gogen-release